### PR TITLE
fix: set the value back into the main map

### DIFF
--- a/contracts/data-feed/src/lib.rs
+++ b/contracts/data-feed/src/lib.rs
@@ -6,7 +6,7 @@ use sep40::{Asset, PriceData};
 pub mod data_feed;
 pub mod reflector;
 pub mod sep40;
-pub mod u64_extensions;
+// pub mod u64_extensions;
 
 use data_feed::DataFeed;
 use sep40::{Sep40, Sep40Admin};


### PR DESCRIPTION
Hopefully this makes sense but I think the reason this wasn't mutating `assets` is that you need to rewrite the value back to `self.assets`. Looking at the `Map::get` implementation, they construct the value from the host, so any updates to it happen to the copy. Would be nice to have a `Map::get_mut`.